### PR TITLE
Create pdsh machines file from template

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,9 +15,6 @@ pdsh_el6_packages:
  - pdsh-mod-netgroup
  - pdsh-rcmd-ssh
 
-# The group in the hosts file we populate
 
 # The group in the hosts file we populate
 pdsh_group: "{{ groups['compute'] }}"
-pdsh_name_var: pxe_name
-pdsh_local_file: "files/machines"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,20 +5,8 @@
  - include: redhat.yml
    when: ansible_os_family == "RedHat"
 
- - name: populate machines file locally
-   lineinfile:
-         dest={{ pdsh_local_file }}
-         regexp='^{{ hostvars[item].inventory_hostname }}$'
-         line="{{ hostvars[item].inventory_hostname }}" 
-         state=present
-         create=yes
-   with_items: "{{ pdsh_group }}"
-   delegate_to: localhost 
-   become: no
-   register: reg_pdsh_machines
-
- - name: copy in /etc/machines
-   copy: src={{ pdsh_local_file }} dest=/etc/machines mode=0644
+ - name: populate machines file
+   template: src='pdsh_machines.j2' dest='/etc/machines' mode='0644' owner=root group=root
 
 # TODO: Make dsh groups
 # - debug: var=groups

--- a/templates/pdsh_machines.j2
+++ b/templates/pdsh_machines.j2
@@ -1,0 +1,3 @@
+{% for item in pdsh_group %}
+{{ hostvars[item].inventory_hostname }}
+{% endfor %}


### PR DESCRIPTION
This patch reduces the time for

ansible-playbook admin.yml --tags=machines

from 46s to 9s on our system. Also, ansible output is more readable is it doesn't fill the screen with a line for every node. Third, it makes sure that the machines file is in sync with the ansible configuration.
