### PR TITLE
Remove pxe_name and pxe variables.

### DIFF
--- a/tests/inventory
+++ b/tests/inventory
@@ -14,9 +14,9 @@ localhost
 localhost
 
 [compute]
-localhost ip_address=10.1.100.1 mac_address=00:11:22:33:44:54 pxe=yes pxe_name=node1
-localhost4 ip_address=10.1.100.2 mac_address=00:11:22:33:44:55 pxe=yes pxe_name=node2
-localhost6 ip_address=10.1.100.3 mac_address=00:11:22:33:44:56 pxe=yes pxe_name=node3
+node1 ip_address=10.1.100.1 mac_address=00:11:22:33:44:54
+node2 ip_address=10.1.100.2 mac_address=00:11:22:33:44:55
+node3 ip_address=10.1.100.3 mac_address=00:11:22:33:44:56
 
 [pxe_bootable_nodes:children]
 compute

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,9 +1,5 @@
 ---
 
- - name: grab facts from compute nodes
-   hosts: compute
-   tasks: [ ]
-
  - hosts: localhost
    remote_user: root
    roles:


### PR DESCRIPTION
These are not necessary for generating the pdsh machines file. Also,
to generate the machines file we don't need to gather facts from the
compute nodes in tests/test.yml, everything we need is in the
inventory already.
