### PR TITLE
Use genders database populated from ansible groups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Emacs backup files
+*~

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ansible-role-pdsh-machines
-=========
+==========================
 
-Installs and sets up a /etc/machines and /etc/dsh/ files for pdsh
+Installs pdsh and sets up a /etc/genders based on ansible groups.
 
 Requirements
 ------------
@@ -35,3 +35,5 @@ MIT
 Author Information
 ------------------
 
+https://github.com/martbhell
+https://github.com/jabl

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,20 +1,19 @@
 ---
 # defaults file for ansible-role-pdsh-machines
 
+# List of pdsh modules conflicting with genders that must be removed
+pdsh_genders_conflict:
+  - pdsh-mod-dshgroup
+  - pdsh-mod-machines
+
 pdsh_el7_packages:
  - pdsh
- - pdsh-mod-dshgroup
- - pdsh-mod-machines
+ - pdsh-mod-genders
  - pdsh-mod-netgroup
  - pdsh-rcmd-ssh
 
 pdsh_el6_packages:
  - pdsh
- - pdsh-mod-dshgroup
  - pdsh-mod-genders
  - pdsh-mod-netgroup
  - pdsh-rcmd-ssh
-
-
-# The group in the hosts file we populate
-pdsh_group: "{{ groups['compute'] }}"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,7 +1,7 @@
 ---
 galaxy_info:
   author: Johan Guldmyr
-  description: Populates /etc/machines and /etc/dsh/groups
+  description: Populates /etc/genders
   company: CSC - IT Center for Science Ltd.
   # If the issue tracker for your role is not on github, uncomment the
   # next line and provide a value

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,16 +8,5 @@
  - name: populate genders file
    template: src='pdsh_genders.j2' dest='/etc/genders' mode='0644' owner=root group=root
 
-# TODO: Make dsh groups
-# - debug: var=groups
-#
-# - name: populate dsh group files locally
-#   lineinfile:
-#         dest='files/dsh/group/{{ item.key }}'
-#         regexp='^{{ inventory_hostname }}$'
-#         line='{{ inventory_hostname }}'
-#         state=present
-#         create=yes
-#   with_dict: groups
-#   delegate_to: localhost 
-#   become: no
+ - name: Remove old /etc/machines to avoid confusion
+   file: src=/etc/machines state=absent

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,4 +9,4 @@
    template: src='pdsh_genders.j2' dest='/etc/genders' mode='0644' owner=root group=root
 
  - name: Remove old /etc/machines to avoid confusion
-   file: src=/etc/machines state=absent
+   file: path=/etc/machines state=absent

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,8 +5,8 @@
  - include: redhat.yml
    when: ansible_os_family == "RedHat"
 
- - name: populate machines file
-   template: src='pdsh_machines.j2' dest='/etc/machines' mode='0644' owner=root group=root
+ - name: populate genders file
+   template: src='pdsh_genders.j2' dest='/etc/genders' mode='0644' owner=root group=root
 
 # TODO: Make dsh groups
 # - debug: var=groups

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -2,6 +2,10 @@
 # tasks file for ansible-role-pdsh-machines
 #
 
+ - name: remove pdsh modules conflicting with genders
+   package: name={{ item }} state=absent
+   with_items: "{{ pdsh_genders_conflict }}"
+
  - name: install pdsh and dependencies EL7
    yum: name={{ item }} state=installed
    with_items: "{{ pdsh_el7_packages }}"

--- a/templates/pdsh_genders.j2
+++ b/templates/pdsh_genders.j2
@@ -1,0 +1,4 @@
+{% for groupname in groups %}
+{% for hname in groups[groupname] %}
+{{ hostvars[hname].inventory_hostname }},{% endfor %} {{ groupname }}
+{% endfor %}

--- a/templates/pdsh_machines.j2
+++ b/templates/pdsh_machines.j2
@@ -1,3 +1,0 @@
-{% for item in pdsh_group %}
-{{ hostvars[item].inventory_hostname }}
-{% endfor %}

--- a/tests/test-in-docker-image.sh
+++ b/tests/test-in-docker-image.sh
@@ -119,8 +119,8 @@ function test_playbook(){
 }
 function extra_tests(){
 
-    echo "TEST: cat /etc/machines"
-    cat /etc/machines
+    echo "TEST: cat /etc/genders"
+    cat /etc/genders
 }
 
 


### PR DESCRIPTION
Switch the pdsh module to using the genders database instead of /etc/machines or /etc/dsh/GROUPNAME, and populate the genders database /etc/genders from the ansible groups.

This gives us easy ssh access to any ansible group via "pdsh -g groupname", and all nodes with "pdsh -a". 

A few potential problems:
1. This is a change in behavior. Previously we populated /etc/machines with the ansible group pxe_bootable_nodes, and "pdsh -a" targeted only these nodes. Now "pdsh -a" will target ALL nodes. I think this is acceptable, provided we (I?) send an email to the fgci-tech list mentioning this.
2. The name of the role is a bit poor now that it no longer generates/uses /etc/machines.
